### PR TITLE
Python 3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ No more `os.system`, `subprocess.check_output` and `subprocess.Popen` :thumbsup:
 ```python
 from pyZZUF import *
 
-print pyZZUF('good').mutate()
+print (pyZZUF(b'good').mutate().tostring().decode())
 ```
 
 #### Options
@@ -19,7 +19,7 @@ print pyZZUF('good').mutate()
 ```python
 from pyZZUF import *
 
-zzuf = pyZZUF('good')
+zzuf = pyZZUF(b'good')
 
 # Random seed (default 0)
 zzuf.set_seed(9)
@@ -49,18 +49,21 @@ zzuf.set_permitted('!', True)
 # Fuzzing mode <mode> ([xor] set unset)
 zzuf.set_fuzz_mode(FUZZ_MODE_XOR)
 
-print zzuf.mutate()
+print (zzuf.mutate().tostring().decode())
 ```
 
 ### Mutagen
 
 ```python
-zzuf = pyZZUF('good')
+import binascii
+from pyZZUF import *
+
+zzuf = pyZZUF(b'good')
 
 for data in zzuf.mutagen(start=0.0, stop=1, step=0.1):
 	if __debug__:
 		seed, ratio, index = data.get_state()
-		print data.tostring().encode('hex'), seed, ratio, index
+		print (binascii.hexlify(data.tostring()), seed, ratio, index)
 	if data == 'bad!':
 		break
 ```
@@ -68,12 +71,15 @@ for data in zzuf.mutagen(start=0.0, stop=1, step=0.1):
 #### Inheritance of the previous state (meat)
 
 ```python
-zzuf = pyZZUF('good')
+import binascii
+from pyZZUF import *
+
+zzuf = pyZZUF(b'good')
 
 for data in zzuf.mutagen(start=0.0, stop=1, step=0.1, inheritance=True):
 	if __debug__:
 		seed, ratio, index = data.get_state()
-		print data.tostring().encode('hex'), seed, ratio, index
+		print (binascii.hexlify(data.tostring()), seed, ratio, index)
 	if data == 'bad!':
 		break
 ```
@@ -113,7 +119,7 @@ $ echo -n "The quick brown fox jumps over the lazy dog" | zzuf -r0.04 | hd
 00000020  68 65 21 6c 61 7a 78 20  66 6f 67                 |he!lazx fog|
 0000002b
 
-$ python -c "import pyZZUF, sys; sys.stdout.write(pyZZUF.pyZZUF('The quick brown fox jumps over the lazy dog', ratio=0.04).mutate().tostring())" | hd
+$ python -c "import pyZZUF, sys; sys.stdout.write(pyZZUF.pyZZUF(b'The quick brown fox jumps over the lazy dog', ratio=0.04).mutate().tostring().decode())" | hd
 
 00000000  54 68 65 20 71 75 69 63  6b 20 62 72 6f 57 6c 20  |The quick broWl |
 00000010  66 4f 58 20 6a 75 6f 70  73 24 6f 76 75 72 20 74  |fOX juops$ovur t|

--- a/README.md
+++ b/README.md
@@ -87,16 +87,19 @@ for data in zzuf.mutagen(start=0.0, stop=1, step=0.1, inheritance=True):
 ### Stream-generator with restoring state of mutator
 
 ```python
-obj = pyZZUF('good')
+import binascii
+from pyZZUF import *
+
+obj = pyZZUF(b'good')
 gen = obj.mutagen(start=0.0, stop=1, step=0.01)
 
 while True:
 	try:
-		data = gen.next()
+		data = next(gen)
 		seed, ratio, index = data.get_state()
 		
 		if __debug__:
-			print data.tostring().encode('hex'), seed, ratio, index
+			print (binascii.hexlify(data.tostring()), seed, ratio, index)
 
 		if seed == 20:
 			# Set next state of generator (<seed>, <ratio>).

--- a/pyZZUF.py
+++ b/pyZZUF.py
@@ -8,9 +8,18 @@ __status__ = 'Production'
 # Original C-code
 # http://caca.zoy.org/wiki/zzuf
 
+import sys
+
 from array import array
 from random import randint
 from ctypes import c_double
+
+# Python 2/3 support
+if sys.version_info[0] == 3:
+	xrange = range
+	integer_types = int
+else:
+	integer_types = (int, long)
 
 # A bit of zzuf-magic :/
 ZZUF_MAGIC0 = 0x12345678
@@ -70,7 +79,7 @@ class pyZZUFArray(array):
 
 	def __add__(self, other):
 		return self.__str__() + other
-	
+
 	def get_state(self):
 		return self._seed, self._ratio, self._iter
 
@@ -118,7 +127,7 @@ class pyZZUF(object):
 		self._buf_length = len(buf)
 
 	def set_seed(self, seed):
-		if not isinstance(seed, (int, long)):
+		if not isinstance(seed, integer_types):
 			raise TypeError('<seed> must be int')
 
 		self._seed = uint32(seed)
@@ -188,10 +197,10 @@ class pyZZUF(object):
 
 	# Could be better, but do we care?
 	def _zz_rand(self, maxv):
-		hi, lo = self._ctx / 12773L, self._ctx % 12773L
-		x = 16807L * lo - 2836L * hi
+		hi, lo = self._ctx // 12773, self._ctx % 12773
+		x = 16807 * lo - 2836 * hi
 		if x <= 0:
-			x += 0x7fffffffL
+			x += 0x7fffffff
 		self._ctx = x
 		return uint32(self._ctx % maxv)
 

--- a/pyZZUF.py
+++ b/pyZZUF.py
@@ -15,11 +15,11 @@ from random import randint
 from ctypes import c_double
 
 # Python 2/3 support
-if sys.version_info[0] == 3:
+if sys.version_info[0] == 2:
+	integer_types = (int, long)
+else:
 	xrange = range
 	integer_types = int
-else:
-	integer_types = (int, long)
 
 # A bit of zzuf-magic :/
 ZZUF_MAGIC0 = 0x12345678


### PR DESCRIPTION
Python 3 support. 
- Define xrange
- Integer types
- Integer divide in _zz_rand
- Update README

Test script attached (test.py.txt). Python2-test.txt shows output for python 2, python3-test.txt for python 3. Results are the same.

[python2-test.txt](https://github.com/nezlooy/pyZZUF/files/587789/python2-test.txt)
[python3-test.txt](https://github.com/nezlooy/pyZZUF/files/587790/python3-test.txt)
[test.py.txt](https://github.com/nezlooy/pyZZUF/files/587791/test.py.txt)
